### PR TITLE
avoid returning non-zero exit status from install

### DIFF
--- a/install
+++ b/install
@@ -176,4 +176,6 @@ popd
 log_start "Reboot into NixOS now? [yn] "
 read -n 1 -r || REPLY=n
 log_end
-[[ $REPLY =~ ^[Yy]$ ]] && reboot
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  reboot
+fi


### PR DESCRIPTION
Just because we don't want to reboot doesn't mean we want to fail...